### PR TITLE
Unsaved-alert

### DIFF
--- a/src/components/ReportEditingBackButton/ReportEditingBackButton.js
+++ b/src/components/ReportEditingBackButton/ReportEditingBackButton.js
@@ -12,7 +12,7 @@ import { HeaderBackButton } from 'react-navigation';
 class ReportEditingBackButton extends React.Component {
     render() {
         return (
-            <HeaderBackButton tintColor='#fff' onPress={() => handleBack(this.props.isUnsaved, this.props.dispatch)} />
+            <HeaderBackButton tintColor='#fff' onPress={() => handleBack(this.props.dispatch, this.props.newReport, this.props.username)} />
         );
     }
 }
@@ -23,28 +23,28 @@ const mapStateToProps = (state) => {
     // TODO: these are probably not needed: remove if so
     /*
     const token         = state.user.token;
-    const username      = state.user.username;
     const templates     = state.templates;
     const reports       = state.reports;
-    const newReport     = state.newReport;
     const title         = state.newReport.title;
     const number        = state.newReport.number;
     const isConnected = state.connection.isConnected;
     */
+    const newReport     = state.newReport;
+    const username      = state.user.username;
     const isUnsaved     = state.newReport.isUnsaved;
 
 
     return {
         /*
-        username,
         templates,
         title,
         number,
-        newReport,
         token,
         reports,
         isConnected,
         */
+        newReport,
+        username,
         isUnsaved,
     };
 };

--- a/src/components/ReportEditingBackButton/ReportEditingBackButton.js
+++ b/src/components/ReportEditingBackButton/ReportEditingBackButton.js
@@ -20,27 +20,9 @@ class ReportEditingBackButton extends React.Component {
 
 // maps redux state to component props. Object that is returned can be accessed via 'this.props' e.g. this.props.email
 const mapStateToProps = (state) => {
-    // TODO: these are probably not needed: remove if so
-    /*
-    const token         = state.user.token;
-    const templates     = state.templates;
-    const reports       = state.reports;
-    const title         = state.newReport.title;
-    const number        = state.newReport.number;
-    const isConnected = state.connection.isConnected;
-    */
     const isUnsaved     = state.reportEditing.isUnsaved;
 
-
     return {
-        /*
-        templates,
-        title,
-        number,
-        token,
-        reports,
-        isConnected,
-        */
         isUnsaved,
     };
 };

--- a/src/components/ReportEditingBackButton/ReportEditingBackButton.js
+++ b/src/components/ReportEditingBackButton/ReportEditingBackButton.js
@@ -12,7 +12,7 @@ import { HeaderBackButton } from 'react-navigation';
 class ReportEditingBackButton extends React.Component {
     render() {
         return (
-            <HeaderBackButton tintColor='#fff' onPress={() => handleBack(this.props.dispatch, this.props.newReport, this.props.username)} />
+            <HeaderBackButton tintColor='#fff' onPress={() => handleBack(this.props.dispatch, this.props.isUnsaved)} />
         );
     }
 }
@@ -29,9 +29,7 @@ const mapStateToProps = (state) => {
     const number        = state.newReport.number;
     const isConnected = state.connection.isConnected;
     */
-    const newReport     = state.newReport;
-    const username      = state.user.username;
-    const isUnsaved     = state.newReport.isUnsaved;
+    const isUnsaved     = state.reportEditing.isUnsaved;
 
 
     return {
@@ -43,8 +41,6 @@ const mapStateToProps = (state) => {
         reports,
         isConnected,
         */
-        newReport,
-        username,
         isUnsaved,
     };
 };

--- a/src/components/ReportEditingBackButton/ReportEditingBackButton.js
+++ b/src/components/ReportEditingBackButton/ReportEditingBackButton.js
@@ -1,0 +1,52 @@
+import { connect } from 'react-redux';
+import React from 'react';
+import { handleBack } from '../../functions/handleBack';
+import { HeaderBackButton } from 'react-navigation';
+
+
+/**
+ *  A wrapper for the back button, that can be connected to Redux.
+ *  This button is used in report editing screens so that it can show
+ *  a confirmation message based on redux data (isUnsaved) and dispatch redux actions accordingly.
+ */
+class ReportEditingBackButton extends React.Component {
+    render() {
+        return (
+            <HeaderBackButton tintColor='#fff' onPress={() => handleBack(this.props.isUnsaved, this.props.dispatch)} />
+        );
+    }
+}
+
+
+// maps redux state to component props. Object that is returned can be accessed via 'this.props' e.g. this.props.email
+const mapStateToProps = (state) => {
+    // TODO: these are probably not needed: remove if so
+    /*
+    const token         = state.user.token;
+    const username      = state.user.username;
+    const templates     = state.templates;
+    const reports       = state.reports;
+    const newReport     = state.newReport;
+    const title         = state.newReport.title;
+    const number        = state.newReport.number;
+    const isConnected = state.connection.isConnected;
+    */
+    const isUnsaved     = state.newReport.isUnsaved;
+
+
+    return {
+        /*
+        username,
+        templates,
+        title,
+        number,
+        newReport,
+        token,
+        reports,
+        isConnected,
+        */
+        isUnsaved,
+    };
+};
+
+export default connect(mapStateToProps)(ReportEditingBackButton);

--- a/src/components/ReportEditingBackButton/index.js
+++ b/src/components/ReportEditingBackButton/index.js
@@ -1,0 +1,3 @@
+import ReportEditingBackButton from './ReportEditingBackButton';
+
+export { ReportEditingBackButton };

--- a/src/functions/handleBack.js
+++ b/src/functions/handleBack.js
@@ -11,6 +11,10 @@ import { NavigationActions } from 'react-navigation';
  *
  * Note that the return values are only needed for the Android hardware back button,
  * and are not necessary with the on-screen back button.
+ *
+ * This function is used:
+ *   1. in an Android BackHandler and is called from there directly
+ *   2. in onPress inside ReportEditingBackButton, that is used in navigation
  * @param isUnsaved
  * @param dispatch
  * @returns {boolean}
@@ -25,12 +29,12 @@ export const handleBack = (isUnsaved = true, dispatch) => {
             'Are you sure you want to leave without saving?',
             [
                 { text: 'Cancel', onPress: () => console.log('Cancel pressed'), style: 'cancel' },
-                { text: 'Save', onPress: () => console.log('No Pressed') },
+                { text: 'Save', onPress: () => console.log('Save Pressed') }, // TODO: add goBack() here
                 // TODO: call the save-method from NewReportScreen or ReportScreen
                 { text: 'Don\'t save', onPress: () => {
                     console.log('Yes Pressed');
-                    dispatch(emptyFields()); // FIXME: this makes the app crash
-                    //dispatch(setUnsaved(false));
+                    //dispatch(emptyFields()); // FIXME: this makes the app crash. Is this necessary?
+                    //dispatch(setUnsaved(false)); // TODO: implement isUnsaved checking
                     dispatch(NavigationActions.back());
                 }
                 },

--- a/src/functions/handleBack.js
+++ b/src/functions/handleBack.js
@@ -1,8 +1,7 @@
 import { Alert } from 'react-native';
-import { emptyFields } from '../redux/actions/newReport';
 import { NavigationActions } from 'react-navigation';
 import { saveDraft } from '../screens/api';
-import { storeDraftByTemplateID } from '../redux/actions/reports';
+import { emptyFields } from '../redux/actions/newReport';
 
 /**
  * Handles the back-navigation logic when editing a report.
@@ -17,8 +16,9 @@ import { storeDraftByTemplateID } from '../redux/actions/reports';
  * This function is used:
  *   1. in an Android BackHandler and is called from there directly
  *   2. in onPress inside ReportEditingBackButton, that is used in navigation
- * @param isUnsaved
- * @param dispatch
+ * @param dispatch Dispatch function from redux
+ * @param newReport The report that will be saved
+ * @param username
  * @returns {boolean}
  */
 export const handleBack = (dispatch, newReport, username) => {
@@ -46,23 +46,21 @@ export const handleBack = (dispatch, newReport, username) => {
                     console.log(newReport);
                     saveDraft(username, template_id, newReport); // give a negative id
 
-                    dispatch(storeDraftByTemplateID(template_id, newReport)); // store drafts together with other reports in reports state)
+                    // this seems to be redundant
+                    //dispatch(storeDraftByTemplateID(template_id, newReport)); // store drafts together with other reports in reports state)
 
                     Alert.alert('Report saved!');
+                    // these are currently handled in componentWillUnmount in the screens that handle report editing
                     //this.setState({ isLoading: true });
                     //this.setState({ isUnsaved: false });
                     //return to template screen and have it refreshed
                     //dispatch(emptyFields()); // FIXME: this makes the app crash. Is this necessary?
                     //this.props.navigation.state.params.refresh(); // TODO: is this necessary?
-                    dispatch(NavigationActions.back());
-
                 }
                 },
-                // TODO: call the save-method from NewReportScreen or ReportScreen
+
                 { text: 'Don\'t save', onPress: () => {
                     console.log('Yes Pressed');
-                    //dispatch(emptyFields()); // FIXME: this makes the app crash. Is this necessary?
-                    //dispatch(setUnsaved(false)); // TODO: implement isUnsaved checking
                     dispatch(NavigationActions.back());
                 }
                 },

--- a/src/functions/handleBack.js
+++ b/src/functions/handleBack.js
@@ -1,7 +1,7 @@
 import { Alert } from 'react-native';
 import { NavigationActions } from 'react-navigation';
 import { saveDraft } from '../screens/api';
-import { emptyFields } from '../redux/actions/newReport';
+import {emptyFields, setSavingRequested} from '../redux/actions/newReport';
 
 /**
  * Handles the back-navigation logic when editing a report.
@@ -22,6 +22,7 @@ import { emptyFields } from '../redux/actions/newReport';
  * @returns {boolean}
  */
 export const handleBack = (dispatch, newReport, username) => {
+    // TODO: remove unused parameters
     // TODO: default value for isUnsaved is used,
     // because checking if report is saved is not implemented yet.
     // When the functionality will be implemented, the default value should become redundant.
@@ -40,22 +41,12 @@ export const handleBack = (dispatch, newReport, username) => {
                 style: 'cancel' },
 
                 { text: 'Save', onPress: () => {
-                    console.log('Save Pressed');
-                    // store report to async storage
-                    console.log('storing newReport:');
-                    console.log(newReport);
-                    saveDraft(username, template_id, newReport); // give a negative id
-
-                    // this seems to be redundant
-                    //dispatch(storeDraftByTemplateID(template_id, newReport)); // store drafts together with other reports in reports state)
-
-                    Alert.alert('Report saved!');
-                    // these are currently handled in componentWillUnmount in the screens that handle report editing
-                    //this.setState({ isLoading: true });
-                    //this.setState({ isUnsaved: false });
-                    //return to template screen and have it refreshed
-                    //dispatch(emptyFields()); // FIXME: this makes the app crash. Is this necessary?
-                    //this.props.navigation.state.params.refresh(); // TODO: is this necessary?
+                    // Saving dispatches a 'flag' through redux that tells
+                    // the current screen that it needs to save the report before
+                    // unmounting.
+                    dispatch(setSavingRequested(true));
+                    // TODO: test for possible race conditions
+                    dispatch(NavigationActions.back());
                 }
                 },
 

--- a/src/functions/handleBack.js
+++ b/src/functions/handleBack.js
@@ -1,0 +1,46 @@
+import { Alert } from 'react-native';
+import { emptyFields } from '../redux/actions/newReport';
+import { NavigationActions } from 'react-navigation';
+
+/**
+ * Handles the back-navigation logic when editing a report.
+ *
+ * This should be used inside a Redux-connected component, so that the
+ * component can get the parameters from Redux and pass them on to this function.
+ * Then this function can i.e. dispatch Redux actions.
+ *
+ * Note that the return values are only needed for the Android hardware back button,
+ * and are not necessary with the on-screen back button.
+ * @param isUnsaved
+ * @param dispatch
+ * @returns {boolean}
+ */
+export const handleBack = (isUnsaved = true, dispatch) => {
+    // TODO: default value for isUnsaved is used,
+    // because checking if report is saved is not implemented yet.
+    // When the functionality will be implemented, the default value should become redundant.
+    if (isUnsaved) {
+        Alert.alert(
+            'You have unsaved changes',
+            'Are you sure you want to leave without saving?',
+            [
+                { text: 'Cancel', onPress: () => console.log('Cancel pressed'), style: 'cancel' },
+                { text: 'Save', onPress: () => console.log('No Pressed') },
+                // TODO: call the save-method from NewReportScreen or ReportScreen
+                { text: 'Don\'t save', onPress: () => {
+                    console.log('Yes Pressed');
+                    dispatch(emptyFields()); // FIXME: this makes the app crash
+                    //dispatch(setUnsaved(false));
+                    dispatch(NavigationActions.back());
+                }
+                },
+            ],
+            { cancelable: false }
+        );
+        return true;
+    }
+    dispatch(NavigationActions.back());
+    // A true return value will prevent the regular handling of the Android back button,
+    // whereas false would allow the previous backhandlers to take action after this.
+    return true;
+};

--- a/src/functions/handleBack.js
+++ b/src/functions/handleBack.js
@@ -34,10 +34,9 @@ export const handleBack = (dispatch, isUnsaved) => {
                     // Saving dispatches a 'flag' through redux that tells
                     // the current screen that it needs to save the report before
                     // unmounting.
-                    // TODO: currently isSavingRequested and isUnsaved are saved in the report. Should they be
-                    // moved to a separate reducer?
                     dispatch(setSavingRequested(true));
-                    // TODO: test for possible race conditions
+                    // This assumes that the screen will have received the new
+                    // isSavingRequested prop before the next line.
                     dispatch(NavigationActions.back());
                 }
                 },

--- a/src/functions/handleBack.js
+++ b/src/functions/handleBack.js
@@ -1,13 +1,15 @@
 import { Alert } from 'react-native';
 import { emptyFields } from '../redux/actions/newReport';
 import { NavigationActions } from 'react-navigation';
+import { saveDraft } from '../screens/api';
+import { storeDraftByTemplateID } from '../redux/actions/reports';
 
 /**
  * Handles the back-navigation logic when editing a report.
  *
  * This should be used inside a Redux-connected component, so that the
  * component can get the parameters from Redux and pass them on to this function.
- * Then this function can i.e. dispatch Redux actions.
+ * Then this function can e.g. dispatch Redux actions.
  *
  * Note that the return values are only needed for the Android hardware back button,
  * and are not necessary with the on-screen back button.
@@ -19,17 +21,43 @@ import { NavigationActions } from 'react-navigation';
  * @param dispatch
  * @returns {boolean}
  */
-export const handleBack = (isUnsaved = true, dispatch) => {
+export const handleBack = (dispatch, newReport, username) => {
     // TODO: default value for isUnsaved is used,
     // because checking if report is saved is not implemented yet.
     // When the functionality will be implemented, the default value should become redundant.
+    const isUnsaved = newReport.isUnsaved == null ? true : newReport.isUnsaved;
+    const { template_id } = newReport;
+    console.assert(template_id != null, 'template id was null');
+
     if (isUnsaved) {
         Alert.alert(
             'You have unsaved changes',
             'Are you sure you want to leave without saving?',
             [
-                { text: 'Cancel', onPress: () => console.log('Cancel pressed'), style: 'cancel' },
-                { text: 'Save', onPress: () => console.log('Save Pressed') }, // TODO: add goBack() here
+                { text: 'Cancel', onPress: () => {
+                    console.log('Cancel pressed');
+                },
+                style: 'cancel' },
+
+                { text: 'Save', onPress: () => {
+                    console.log('Save Pressed');
+                    // store report to async storage
+                    console.log('storing newReport:');
+                    console.log(newReport);
+                    saveDraft(username, template_id, newReport); // give a negative id
+
+                    dispatch(storeDraftByTemplateID(template_id, newReport)); // store drafts together with other reports in reports state)
+
+                    Alert.alert('Report saved!');
+                    //this.setState({ isLoading: true });
+                    //this.setState({ isUnsaved: false });
+                    //return to template screen and have it refreshed
+                    //dispatch(emptyFields()); // FIXME: this makes the app crash. Is this necessary?
+                    //this.props.navigation.state.params.refresh(); // TODO: is this necessary?
+                    dispatch(NavigationActions.back());
+
+                }
+                },
                 // TODO: call the save-method from NewReportScreen or ReportScreen
                 { text: 'Don\'t save', onPress: () => {
                     console.log('Yes Pressed');

--- a/src/functions/handleBack.js
+++ b/src/functions/handleBack.js
@@ -1,7 +1,6 @@
 import { Alert } from 'react-native';
 import { NavigationActions } from 'react-navigation';
-import { saveDraft } from '../screens/api';
-import {emptyFields, setSavingRequested} from '../redux/actions/newReport';
+import { setSavingRequested } from '../redux/actions/reportEditing';
 
 /**
  * Handles the back-navigation logic when editing a report.
@@ -17,19 +16,10 @@ import {emptyFields, setSavingRequested} from '../redux/actions/newReport';
  *   1. in an Android BackHandler and is called from there directly
  *   2. in onPress inside ReportEditingBackButton, that is used in navigation
  * @param dispatch Dispatch function from redux
- * @param newReport The report that will be saved
- * @param username
+ * @param isUnsaved
  * @returns {boolean}
  */
-export const handleBack = (dispatch, newReport, username) => {
-    // TODO: remove unused parameters
-    // TODO: default value for isUnsaved is used,
-    // because checking if report is saved is not implemented yet.
-    // When the functionality will be implemented, the default value should become redundant.
-    const isUnsaved = newReport.isUnsaved == null ? true : newReport.isUnsaved;
-    const { template_id } = newReport;
-    console.assert(template_id != null, 'template id was null');
-
+export const handleBack = (dispatch, isUnsaved) => {
     if (isUnsaved) {
         Alert.alert(
             'You have unsaved changes',

--- a/src/functions/handleBack.js
+++ b/src/functions/handleBack.js
@@ -44,6 +44,8 @@ export const handleBack = (dispatch, newReport, username) => {
                     // Saving dispatches a 'flag' through redux that tells
                     // the current screen that it needs to save the report before
                     // unmounting.
+                    // TODO: currently isSavingRequested and isUnsaved are saved in the report. Should they be
+                    // moved to a separate reducer?
                     dispatch(setSavingRequested(true));
                     // TODO: test for possible race conditions
                     dispatch(NavigationActions.back());
@@ -51,7 +53,7 @@ export const handleBack = (dispatch, newReport, username) => {
                 },
 
                 { text: 'Don\'t save', onPress: () => {
-                    console.log('Yes Pressed');
+                    dispatch(setSavingRequested(false));
                     dispatch(NavigationActions.back());
                 }
                 },

--- a/src/navigation/AppNavigation.js
+++ b/src/navigation/AppNavigation.js
@@ -28,6 +28,9 @@ const TemplateStack = StackNavigator({
             header:
                 <View style={ navigationStyles.HeaderContainer}>
                     <OfflineNotice />
+                    <View style={ { flex:1,justifyContent: 'center',alignItems: 'center' } }>
+                        <Text style={ navigationStyles.ScreenHeaderTemplates }>{ strings('templates.templates') }</Text>
+                    </View>
                     <Icon
                         name={'menu'}
                         type={'feather'}
@@ -35,9 +38,6 @@ const TemplateStack = StackNavigator({
                         containerStyle={navigationStyles.menuIconContainer}
                         onPress={() => { navigation.navigate('DrawerOpen'); }}>
                     </Icon>
-                    <View style={ { flex:1,justifyContent: 'center',alignItems: 'center' } }>
-                        <Text style={ navigationStyles.ScreenHeaderTemplates }>{ strings('templates.templates') }</Text>
-                    </View>
                 </View>
         })
     },

--- a/src/navigation/AppNavigation.js
+++ b/src/navigation/AppNavigation.js
@@ -14,6 +14,7 @@ import connectionReducer from '../redux/reducers/connection';
 import { strings } from '../locales/i18n';
 import { Alert } from 'react-native';
 import OfflineNotice from '../components/OfflineNotice/OfflineNotice';
+import { ReportEditingBackButton } from '../components/ReportEditingBackButton';
 
 export const LOGGED_OUT_ROUTE_NAME = 'loginScreen';
 export const LOGGED_IN_ROUTE_NAME = 'loggedInDrawer';
@@ -52,24 +53,10 @@ const TemplateStack = StackNavigator({
                    <OfflineNotice
                        hidden={false}
                        barStyle="light-content"/>
-                   <HeaderBackButton
+                   <ReportEditingBackButton
                        tintColor='#fff'
                        style={ navigationStyles.headerBackStyle }
-                       onPress={() => {
-                           Alert.alert(
-                               'You have unsaved changes',
-                               'Are you sure you want to leave without saving?',
-                               [
-                                   { text: 'Cancel', onPress: () => console.log('Cancel pressed'), style: 'cancel' },
-                                   { text: 'Save', onPress: () => ReportScreen.save() }, // FIXME: save isn't static and can't be called here!
-                                   { text: 'Don\'t save', onPress: () => {
-                                       console.log('Yes Pressed');
-                                       navigation.goBack(null); }
-                                   },
-                               ],
-                               { cancelable: false }
-                           );
-                       }}/>
+                   />
                    <View style={ { flex:1,justifyContent: 'center',alignItems: 'center' } }>
                        <Text style={ navigationStyles.ScreenHeader }>{ strings('createNew.createNew') }</Text>
                    </View>
@@ -83,10 +70,10 @@ const TemplateStack = StackNavigator({
             header:
                 <View style={ navigationStyles.HeaderContainer}>
                     <OfflineNotice />
-                    <HeaderBackButton
+                    <ReportEditingBackButton
                         tintColor='#fff'
                         style={ navigationStyles.headerBackStyle }
-                        onPress={() => navigation.goBack(null) }/>
+                    />
                     <View style={ { flex:1,justifyContent: 'center',alignItems: 'center' } }>
                         <Text style={ navigationStyles.ScreenHeader }>{ strings('templates.report') }</Text>
                     </View>

--- a/src/navigation/AppNavigation.js
+++ b/src/navigation/AppNavigation.js
@@ -20,6 +20,7 @@ export const LOGGED_IN_ROUTE_NAME = 'loggedInDrawer';
 
 // The stack that is contained within the logged in drawer
 const TemplateStack = StackNavigator({
+    //TODO pressing Icon does nothing on IOS - fix bug, navigation problems?.
     Templates: {
         screen: TemplateScreen,
         navigationOptions: ({ navigation }) => ({
@@ -40,6 +41,7 @@ const TemplateStack = StackNavigator({
                 </View>
         })
     },
+    //TODO add save property to Save?
     NewReport: {
         screen: NewReportScreen,
         navigationOptions: ({ navigation }) => ({

--- a/src/navigation/AppNavigation.js
+++ b/src/navigation/AppNavigation.js
@@ -61,7 +61,7 @@ const TemplateStack = StackNavigator({
                                'Are you sure you want to leave without saving?',
                                [
                                    { text: 'Cancel', onPress: () => console.log('Cancel pressed'), style: 'cancel' },
-                                   { text: 'Save', onPress: () => ReportScreen.save() },
+                                   { text: 'Save', onPress: () => ReportScreen.save() }, // FIXME: save isn't static and can't be called here!
                                    { text: 'Don\'t save', onPress: () => {
                                        console.log('Yes Pressed');
                                        navigation.goBack(null); }

--- a/src/navigation/AppNavigation.js
+++ b/src/navigation/AppNavigation.js
@@ -59,8 +59,8 @@ const TemplateStack = StackNavigator({
                                'Are you sure you want to leave without saving?',
                                [
                                    { text: 'Cancel', onPress: () => console.log('Cancel pressed'), style: 'cancel' },
-                                   { text: 'No', onPress: () => console.log('No Pressed') },
-                                   { text: 'Yes', onPress: () => {
+                                   { text: 'Save', onPress: () => ReportScreen.save() },
+                                   { text: 'Don\'t save', onPress: () => {
                                        console.log('Yes Pressed');
                                        navigation.goBack(null); }
                                    },

--- a/src/redux/actions/newReport.js
+++ b/src/redux/actions/newReport.js
@@ -6,6 +6,7 @@ export const SET_UNSAVED = 'SET_UNSAVED';
 export const INSERT_DATE = 'INSERT_DATE';
 export const CREATE_DRAFT = 'CREATE_DRAFT';
 export const OPEN_REPORT = 'OPEN_REPORT';
+export const SET_SAVING_REQUESTED = 'SET_SAVING_REQUESTED';
 
 export const createDraft = (draft) => ({
     type: CREATE_DRAFT,
@@ -41,4 +42,9 @@ export const emptyFields = () => ({
 export const setUnsaved = ( isUnsaved ) => ({
     type: SET_UNSAVED,
     isUnsaved: isUnsaved,
+});
+
+export const setSavingRequested = ( isSavingRequested ) => ({
+    type: SET_SAVING_REQUESTED,
+    isSavingRequested: isSavingRequested,
 });

--- a/src/redux/actions/newReport.js
+++ b/src/redux/actions/newReport.js
@@ -2,11 +2,10 @@
 export const INSERT_TITLE   = 'INSERT_TITLE';
 export const INSERT_FIELD_ANSWER = 'INSERT_FIELD_ANSWER';
 export const EMPTY_FIELDS = 'EMPTY_FIELDS';
-export const SET_UNSAVED = 'SET_UNSAVED';
 export const INSERT_DATE = 'INSERT_DATE';
 export const CREATE_DRAFT = 'CREATE_DRAFT';
 export const OPEN_REPORT = 'OPEN_REPORT';
-export const SET_SAVING_REQUESTED = 'SET_SAVING_REQUESTED';
+
 
 export const createDraft = (draft) => ({
     type: CREATE_DRAFT,
@@ -37,14 +36,4 @@ export const insertFieldAnswer = ( field, value, isOption ) => ({
 
 export const emptyFields = () => ({
     type: EMPTY_FIELDS
-});
-
-export const setUnsaved = ( isUnsaved ) => ({
-    type: SET_UNSAVED,
-    isUnsaved: isUnsaved,
-});
-
-export const setSavingRequested = ( isSavingRequested ) => ({
-    type: SET_SAVING_REQUESTED,
-    isSavingRequested: isSavingRequested,
 });

--- a/src/redux/actions/reportEditing.js
+++ b/src/redux/actions/reportEditing.js
@@ -1,0 +1,13 @@
+export const SET_UNSAVED = 'SET_UNSAVED';
+export const SET_SAVING_REQUESTED = 'SET_SAVING_REQUESTED';
+
+
+export const setUnsaved = ( isUnsaved ) => ({
+    type: SET_UNSAVED,
+    isUnsaved: isUnsaved,
+});
+
+export const setSavingRequested = ( isSavingRequested ) => ({
+    type: SET_SAVING_REQUESTED,
+    isSavingRequested: isSavingRequested,
+});

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -7,6 +7,7 @@ import newReport from './newReport';
 import navReducer from './navReducer';
 import preview from './preview';
 import connection from './connection';
+import reportEditing from './reportEditing';
 
 export default combineReducers ({
     user,
@@ -16,4 +17,5 @@ export default combineReducers ({
     nav: navReducer,
     preview,
     connection,
+    reportEditing,
 });

--- a/src/redux/reducers/newReport.js
+++ b/src/redux/reducers/newReport.js
@@ -5,7 +5,8 @@ import {
     INSERT_FIELD_ANSWER,
     EMPTY_FIELDS, SET_UNSAVED,
     OPEN_REPORT,
-    CREATE_DRAFT
+    CREATE_DRAFT,
+    SET_SAVING_REQUESTED,
 } from '../actions/newReport';
 
 const initialState = {};
@@ -68,6 +69,12 @@ const newReportReducer = (state = initialState, action) => {
             return {
                 ...state,
                 isUnsaved: action.isUnsaved,
+            };
+        }
+        case SET_SAVING_REQUESTED: {
+            return {
+                ...state,
+                isSavingRequested: action.isSavingRequested
             };
         }
         default: {

--- a/src/redux/reducers/newReport.js
+++ b/src/redux/reducers/newReport.js
@@ -3,10 +3,9 @@ import {
     INSERT_TITLE,
     INSERT_DATE,
     INSERT_FIELD_ANSWER,
-    EMPTY_FIELDS, SET_UNSAVED,
+    EMPTY_FIELDS,
     OPEN_REPORT,
     CREATE_DRAFT,
-    SET_SAVING_REQUESTED,
 } from '../actions/newReport';
 
 const initialState = {};
@@ -65,18 +64,7 @@ const newReportReducer = (state = initialState, action) => {
         case EMPTY_FIELDS: {
             return initialState;
         }
-        case SET_UNSAVED: {
-            return {
-                ...state,
-                isUnsaved: action.isUnsaved,
-            };
-        }
-        case SET_SAVING_REQUESTED: {
-            return {
-                ...state,
-                isSavingRequested: action.isSavingRequested
-            };
-        }
+
         default: {
             return state;
         }

--- a/src/redux/reducers/newReport.js
+++ b/src/redux/reducers/newReport.js
@@ -59,7 +59,8 @@ const newReportReducer = (state = initialState, action) => {
             return insertAnswer(state, action);
         }
         case OPEN_REPORT: {
-            return action.report;
+            // Create deep copy, so that modifying the opened report doesn't affect the version saved in store.reports
+            return JSON.parse(JSON.stringify(action.report));
         }
         case EMPTY_FIELDS: {
             return initialState;

--- a/src/redux/reducers/reportEditing.js
+++ b/src/redux/reducers/reportEditing.js
@@ -1,0 +1,31 @@
+import {
+    SET_UNSAVED,
+    SET_SAVING_REQUESTED,
+} from '../actions/reportEditing';
+
+const initialState = {
+    isUnsaved: false,
+    isSavingRequested: false,
+};
+
+const reportEditingReducer = (state = initialState, action) => {
+    switch (action.type) {
+        case SET_UNSAVED: {
+            return {
+                ...state,
+                isUnsaved: action.isUnsaved,
+            };
+        }
+        case SET_SAVING_REQUESTED: {
+            return {
+                ...state,
+                isSavingRequested: action.isSavingRequested
+            };
+        }
+        default: {
+            return state;
+        }
+    }
+};
+
+export default reportEditingReducer;

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, StatusBar, Keyboard, NetInfo, Platform, AsyncStorage, View } from 'react-native';
+import { Text, StatusBar, Keyboard, NetInfo, AsyncStorage } from 'react-native';
 import { connect } from 'react-redux';
 
 import loginStyles from './style/loginStyles';
@@ -39,11 +39,11 @@ export class LoginScreen extends React.Component {
         isNetworkConnected()
             .then(isConnected => {
                 this.props.dispatch(setInitialConnection({ connectionStatus: isConnected }));})
-            .then(isConnected => Platform.OS === 'android' ? NetInfo.isConnected.addEventListener('connectionChange', this.handleConnectionChange) : '');
+            .then(isConnected => NetInfo.isConnected.addEventListener('connectionChange', this.handleConnectionChange));
     }
 
     componentWillUnmount() {
-        if (Platform.OS === 'android') { NetInfo.isConnected.removeEventListener('connectionChange', this.handleConnectionChange); }
+        NetInfo.isConnected.removeEventListener('connectionChange', this.handleConnectionChange);
     }
 
     handleConnectionChange = isConnected => {
@@ -80,6 +80,7 @@ export class LoginScreen extends React.Component {
     render() {
         return (
             <AppBackground>
+                <OfflineNotice />
                 <StatusBar
                     backgroundColor={ this.props.isConnected ? '#3d4f7c' : '#b52424'}
                     hidden={false}

--- a/src/screens/NewReportScreen.js
+++ b/src/screens/NewReportScreen.js
@@ -25,6 +25,7 @@ import { createNewReport, saveDraft, fetchEmptyTemplate } from './api';
 import { strings } from '../locales/i18n';
 import { emptyFields, insertFieldAnswer, insertTitle, insertDate, createDraft } from '../redux/actions/newReport';
 import { storeDraftByTemplateID } from '../redux/actions/reports';
+import { handleBack } from '../functions/handleBack';
 
 import newReportStyles from './style/newReportStyles';
 import templateScreenStyles from './style/templateScreenStyles';
@@ -32,48 +33,7 @@ import styles from '../components/Dropdown/styles';
 import EStyleSheet from 'react-native-extended-stylesheet';
 
 
-/**
- * Handles the back-navigation logic in newReportScreen.
- *
- * This should be used inside a Redux-connected component, so that the
- * component can get the parameters from Redux and pass them on to this function.
- * Then this function can i.e. dispatch Redux actions.
- *
- * Note that the return values are only needed for the Android hardware back button,
- * and are not necessary with the on-screen back button.
- * @param isUnsaved
- * @param dispatch
- * @returns {boolean}
- */
-const handleBack = (isUnsaved = true, dispatch) => {
-    // TODO: default value for isUnsaved is used,
-    // because checking if report is saved is not implemented yet.
-    // When the functionality will be implemented, the default value should become redundant.
-    if (isUnsaved) {
-        Alert.alert(
-            'You have unsaved changes',
-            'Are you sure you want to leave without saving?',
-            [
-                { text: 'Cancel', onPress: () => console.log('Cancel pressed'), style: 'cancel' },
-                { text: 'Save', onPress: () => console.log('No Pressed') },
-                // TODO: call the save-method from NewReportScreen or ReportScreen
-                { text: 'Don\'t save', onPress: () => {
-                    console.log('Yes Pressed');
-                    dispatch(emptyFields()); // FIXME: this makes the app crash
-                    //dispatch(setUnsaved(false));
-                    dispatch(NavigationActions.back());
-                }
-                },
-            ],
-            { cancelable: false }
-        );
-        return true;
-    }
-    dispatch(NavigationActions.back());
-    // A true return value will prevent the regular handling of the Android back button,
-    // whereas false would allow the previous backhandlers to take action after this.
-    return true;
-};
+
 
 //A wrapper for the back button, that can be connected to Redux
 class HeaderBackButtonWrapper extends React.Component {

--- a/src/screens/NewReportScreen.js
+++ b/src/screens/NewReportScreen.js
@@ -72,9 +72,9 @@ export class NewReportScreen extends React.Component {
         // Removes the BackHandler EventListener when unmounting
         BackHandler.removeEventListener('hardwareBackPress', this._handleBack);
 
-        this.setState({ isLoading: true });
-        this.setState({ isUnsaved: false });
-        this.props.navigation.state.params.refresh();
+        if (this.props.isSavingRequested) {
+            this.save();
+        }
     }
 
     // TODO come up with a better name
@@ -97,20 +97,19 @@ export class NewReportScreen extends React.Component {
         const { username, newReport } = this.props;
         const { templateID } = this.props.navigation.state.params;
         const report = newReport;
-        report.report_id = saveDraft(username, templateID, report); // give a negative id
-
-        this.props.dispatch(storeDraftByTemplateID(templateID, report)); // store drafts together with other reports in reports state)
-
+        saveDraft(username, templateID, report); // give a negative id
         Alert.alert('Report saved!');
         this.setState({ isLoading: true });
-
-        //this.setState({ isUnsaved: false });
-
-        //return to template screen and have it refreshed
+        //refresh template screen
         this.props.dispatch(emptyFields());
         this.props.navigation.state.params.refresh();
-        this.props.navigation.dispatch(NavigationActions.back());
     };
+
+    //A helper method that calls save and then navigates back
+    saveAndLeave = () => {
+        this.save();
+        this.props.navigation.goBack();
+    }
 
     // Inserts data to server with a post method.
     send = () => {
@@ -424,7 +423,7 @@ export class NewReportScreen extends React.Component {
                             />
                         </View>
                         {renderedFields}
-                        <Button title={strings('createNew.save')} key={999} type={'save'} onPress={() => this.save()}/>
+                        <Button title={strings('createNew.save')} key={999} type={'save'} onPress={() => this.saveAndLeave()}/>
                         <Button title={strings('createNew.send')} type={'send'} onPress={() => this.send()}/>
                     </ScrollView>
                 </View>
@@ -444,6 +443,7 @@ const mapStateToProps = (state) => {
     const number        = state.newReport.number;
     const isUnsaved     = state.newReport.isUnsaved;
     const isConnected = state.connection.isConnected;
+    const isSavingRequested = state.newReport.isSavingRequested;
 
     return {
         username,
@@ -455,6 +455,7 @@ const mapStateToProps = (state) => {
         reports,
         isUnsaved,
         isConnected,
+        isSavingRequested,
     };
 };
 

--- a/src/screens/NewReportScreen.js
+++ b/src/screens/NewReportScreen.js
@@ -9,7 +9,7 @@ import {
     TextInput,
     View
 } from 'react-native';
-import { HeaderBackButton, NavigationActions } from 'react-navigation';
+import { NavigationActions } from 'react-navigation';
 import { Icon } from 'react-native-elements';
 import moment from 'moment';
 import { connect } from 'react-redux';

--- a/src/screens/NewReportScreen.js
+++ b/src/screens/NewReportScreen.js
@@ -56,7 +56,7 @@ export class NewReportScreen extends React.Component {
         };
     }
 
-    _handleBack = () => handleBack(this.props.isUnsaved, this.props.dispatch);
+    _handleBack = () => handleBack(this.props.dispatch, this.props.newReport, this.props.username);
 
     componentWillMount() {
         // BackHandler for detecting hardware button presses for back navigation (Android only)
@@ -68,8 +68,13 @@ export class NewReportScreen extends React.Component {
     }
 
     componentWillUnmount() {
+        console.log('calling this');
         // Removes the BackHandler EventListener when unmounting
         BackHandler.removeEventListener('hardwareBackPress', this._handleBack);
+
+        this.setState({ isLoading: true });
+        this.setState({ isUnsaved: false });
+        this.props.navigation.state.params.refresh();
     }
 
     // TODO come up with a better name

--- a/src/screens/NewReportScreen.js
+++ b/src/screens/NewReportScreen.js
@@ -45,17 +45,21 @@ import EStyleSheet from 'react-native-extended-stylesheet';
  * @param dispatch
  * @returns {boolean}
  */
-const handleBack = (isUnsaved, dispatch) => {
+const handleBack = (isUnsaved = true, dispatch) => {
+    // TODO: default value for isUnsaved is used,
+    // because checking if report is saved is not implemented yet.
+    // When the functionality will be implemented, the default value should become redundant.
     if (isUnsaved) {
         Alert.alert(
             'You have unsaved changes',
             'Are you sure you want to leave without saving?',
             [
                 { text: 'Cancel', onPress: () => console.log('Cancel pressed'), style: 'cancel' },
-                { text: 'No', onPress: () => console.log('No Pressed') },
-                { text: 'Yes', onPress: () => {
+                { text: 'Save', onPress: () => console.log('No Pressed') },
+                // TODO: call the save-method from NewReportScreen or ReportScreen
+                { text: 'Don\'t save', onPress: () => {
                     console.log('Yes Pressed');
-                    dispatch(emptyFields());
+                    dispatch(emptyFields()); // FIXME: this makes the app crash
                     //dispatch(setUnsaved(false));
                     dispatch(NavigationActions.back());
                 }

--- a/src/screens/NewReportScreen.js
+++ b/src/screens/NewReportScreen.js
@@ -26,6 +26,7 @@ import { strings } from '../locales/i18n';
 import { emptyFields, insertFieldAnswer, insertTitle, insertDate, createDraft } from '../redux/actions/newReport';
 import { storeDraftByTemplateID } from '../redux/actions/reports';
 import { handleBack } from '../functions/handleBack';
+import { ReportEditingBackButton } from '../components/ReportEditingBackButton';
 
 import newReportStyles from './style/newReportStyles';
 import templateScreenStyles from './style/templateScreenStyles';
@@ -35,50 +36,13 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 
 
 
-//A wrapper for the back button, that can be connected to Redux
-class HeaderBackButtonWrapper extends React.Component {
-    render() {
-        return (
-            <HeaderBackButton tintColor='#fff' onPress={() => handleBack(this.props.isUnsaved, this.props.dispatch)} />
-        );
-    }
-}
-
-
-// maps redux state to component props. Object that is returned can be accessed via 'this.props' e.g. this.props.email
-const mapStateToProps = (state) => {
-    const token         = state.user.token;
-    const username      = state.user.username;
-    const templates     = state.templates;
-    const reports       = state.reports;
-    const newReport     = state.newReport;
-    const title         = state.newReport.title;
-    const number        = state.newReport.number;
-    const isUnsaved     = state.newReport.isUnsaved;
-    const isConnected = state.connection.isConnected;
-
-    return {
-        username,
-        templates,
-        title,
-        number,
-        newReport,
-        token,
-        reports,
-        isUnsaved,
-        isConnected,
-    };
-};
-
-const HeaderBackButtonWrapperWithRedux = connect(mapStateToProps)(HeaderBackButtonWrapper);
-
 
 // "export" necessary in order to test component without Redux store
 export class NewReportScreen extends React.Component {
     static navigationOptions = () => {
         return {
             // the Redux-connected on-screen back button is set here
-            headerLeft: HeaderBackButtonWrapperWithRedux,
+            headerLeft: ReportEditingBackButton,
         };
     };
 
@@ -464,5 +428,29 @@ export class NewReportScreen extends React.Component {
     }
 }
 
+// maps redux state to component props. Object that is returned can be accessed via 'this.props' e.g. this.props.email
+const mapStateToProps = (state) => {
+    const token         = state.user.token;
+    const username      = state.user.username;
+    const templates     = state.templates;
+    const reports       = state.reports;
+    const newReport     = state.newReport;
+    const title         = state.newReport.title;
+    const number        = state.newReport.number;
+    const isUnsaved     = state.newReport.isUnsaved;
+    const isConnected = state.connection.isConnected;
+
+    return {
+        username,
+        templates,
+        title,
+        number,
+        newReport,
+        token,
+        reports,
+        isUnsaved,
+        isConnected,
+    };
+};
 
 export default connect(mapStateToProps)(NewReportScreen);

--- a/src/screens/NewReportScreen.js
+++ b/src/screens/NewReportScreen.js
@@ -32,6 +32,7 @@ import newReportStyles from './style/newReportStyles';
 import templateScreenStyles from './style/templateScreenStyles';
 import styles from '../components/Dropdown/styles';
 import EStyleSheet from 'react-native-extended-stylesheet';
+import { setUnsaved } from '../redux/actions/reportEditing';
 
 
 
@@ -56,11 +57,13 @@ export class NewReportScreen extends React.Component {
         };
     }
 
-    _handleBack = () => handleBack(this.props.dispatch, this.props.newReport, this.props.username);
+    _handleBack = () => handleBack(this.props.dispatch, this.props.isUnsaved);
 
     componentWillMount() {
         // BackHandler for detecting hardware button presses for back navigation (Android only)
         BackHandler.addEventListener('hardwareBackPress', this._handleBack);
+        // TODO: implement checking isUnsaved, now it is assumed to be true.
+        this.props.dispatch(setUnsaved(true));
     }
 
     componentDidMount() {
@@ -71,10 +74,10 @@ export class NewReportScreen extends React.Component {
         console.log('calling this');
         // Removes the BackHandler EventListener when unmounting
         BackHandler.removeEventListener('hardwareBackPress', this._handleBack);
-
         if (this.props.isSavingRequested) {
             this.save();
         }
+        this.props.dispatch(setUnsaved(false));
     }
 
     // TODO come up with a better name
@@ -441,9 +444,9 @@ const mapStateToProps = (state) => {
     const newReport     = state.newReport;
     const title         = state.newReport.title;
     const number        = state.newReport.number;
-    const isUnsaved     = state.newReport.isUnsaved;
+    const isUnsaved     = state.reportEditing.isUnsaved;
     const isConnected = state.connection.isConnected;
-    const isSavingRequested = state.newReport.isSavingRequested;
+    const isSavingRequested = state.reportEditing.isSavingRequested;
 
     return {
         username,

--- a/src/screens/ReportScreen.js
+++ b/src/screens/ReportScreen.js
@@ -13,7 +13,7 @@ import { Datepicker } from '../components/Datepicker';
 import { AppBackground } from '../components/AppBackground';
 import { createNewReport, removeDraft, saveDraft } from './api';
 import { strings } from '../locales/i18n';
-import { insertFieldAnswer, emptyFields, openReport, insertTitle } from '../redux/actions/newReport';
+import { insertFieldAnswer, emptyFields, openReport, insertTitle, setUnsaved } from '../redux/actions/newReport';
 
 import newReportStyles from './style/newReportStyles';
 import templateScreenStyles from './style/templateScreenStyles';
@@ -42,6 +42,9 @@ export class ReportScreen extends React.Component {
 
         this.props.dispatch(openReport(report));
         this.setState({ fields: fields, isEditable: reportID < 0, isLoading : false });
+        // TODO: implement checking isUnsaved. This line temporarily disables the confirmation
+        // alert when leaving. If isUnsaved would be true, the alert would be shown.
+        this.props.dispatch(setUnsaved(false));
     }
 
     // delete draft from asyncstorage

--- a/src/screens/ReportScreen.js
+++ b/src/screens/ReportScreen.js
@@ -16,7 +16,8 @@ import { Datepicker } from '../components/Datepicker';
 import { AppBackground } from '../components/AppBackground';
 import { createNewReport, removeDraft, saveDraft } from './api';
 import { strings } from '../locales/i18n';
-import { insertFieldAnswer, emptyFields, openReport, insertTitle, setUnsaved } from '../redux/actions/newReport';
+import { insertFieldAnswer, emptyFields, openReport, insertTitle } from '../redux/actions/newReport';
+import { setUnsaved } from '../redux/actions/reportEditing';
 
 import newReportStyles from './style/newReportStyles';
 import templateScreenStyles from './style/templateScreenStyles';
@@ -30,7 +31,6 @@ export class ReportScreen extends React.Component {
         super(props);
         this.state = {
             title           : null,
-            isUnsaved       : true,
             isLoading       : true,
             number          : '',
             isEditable      : false,
@@ -38,7 +38,7 @@ export class ReportScreen extends React.Component {
         };
     }
 
-    _handleBack = () => handleBack(this.props.dispatch, this.props.report, this.props.username);
+    _handleBack = () => handleBack(this.props.dispatch, this.props.isUnsaved);
 
     componentDidMount() {
         const { templateID, reportID } = this.props.navigation.state.params;
@@ -48,9 +48,10 @@ export class ReportScreen extends React.Component {
 
         this.props.dispatch(openReport(report));
         this.setState({ fields: fields, isEditable: reportID < 0, isLoading : false });
-        // TODO: implement checking isUnsaved. This line temporarily disables the confirmation
-        // alert when leaving. If isUnsaved would be true, the alert would be shown.
-        this.props.dispatch(setUnsaved(true));
+        // TODO: implement checking isUnsaved. Now drafts are always assumed to be unsaved.
+        if (reportID < 0) {
+            this.props.dispatch(setUnsaved(true));
+        }
 
         // BackHandler for detecting hardware button presses for back navigation (Android only)
         BackHandler.addEventListener('hardwareBackPress', this._handleBack);
@@ -63,6 +64,7 @@ export class ReportScreen extends React.Component {
         if (this.props.isSavingRequested) {
             this.save();
         }
+        this.props.dispatch(setUnsaved(false));
     }
 
     // delete draft from asyncstorage
@@ -380,7 +382,8 @@ const mapStateToProps = (state) => {
     const reports       = state.reports;
     const templates     = state.templates;
     const report        = state.newReport;
-    const isSavingRequested = state.newReport.isSavingRequested;
+    const isUnsaved     = state.reportEditing.isUnsaved;
+    const isSavingRequested = state.reportEditing.isSavingRequested;
     return {
         username,
         report,
@@ -388,7 +391,8 @@ const mapStateToProps = (state) => {
         token,
         reports,
         templates,
-        isSavingRequested
+        isSavingRequested,
+        isUnsaved,
     };
 };
 

--- a/src/screens/ReportScreen.js
+++ b/src/screens/ReportScreen.js
@@ -20,7 +20,7 @@ import { insertFieldAnswer, emptyFields, openReport, insertTitle, setUnsaved } f
 
 import newReportStyles from './style/newReportStyles';
 import templateScreenStyles from './style/templateScreenStyles';
-import {handleBack} from "../functions/handleBack";
+import { handleBack } from '../functions/handleBack';
 // import styles from '../components/Dropdown/styles';
 // import EStyleSheet from 'react-native-extended-stylesheet';
 

--- a/src/screens/ReportScreen.js
+++ b/src/screens/ReportScreen.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { /*Button, */ View, ScrollView, TextInput, Alert, Text, ActivityIndicator, Linking, /*Picker*/ } from 'react-native';
+import {
+    /*Button, */ View, ScrollView, TextInput, Alert, Text, ActivityIndicator, Linking,
+    BackHandler, /*Picker*/
+} from 'react-native';
 import { NavigationActions } from 'react-navigation';
 import { Icon } from 'react-native-elements';
 // import ModalDropdown from 'react-native-modal-dropdown';
@@ -17,6 +20,7 @@ import { insertFieldAnswer, emptyFields, openReport, insertTitle, setUnsaved } f
 
 import newReportStyles from './style/newReportStyles';
 import templateScreenStyles from './style/templateScreenStyles';
+import {handleBack} from "../functions/handleBack";
 // import styles from '../components/Dropdown/styles';
 // import EStyleSheet from 'react-native-extended-stylesheet';
 
@@ -34,6 +38,8 @@ export class ReportScreen extends React.Component {
         };
     }
 
+    _handleBack = () => handleBack(this.props.dispatch, this.props.newReport, this.props.username);
+
     componentDidMount() {
         const { templateID, reportID } = this.props.navigation.state.params;
         const { reports, templates } = this.props;
@@ -45,6 +51,14 @@ export class ReportScreen extends React.Component {
         // TODO: implement checking isUnsaved. This line temporarily disables the confirmation
         // alert when leaving. If isUnsaved would be true, the alert would be shown.
         this.props.dispatch(setUnsaved(false));
+
+        // BackHandler for detecting hardware button presses for back navigation (Android only)
+        BackHandler.addEventListener('hardwareBackPress', this._handleBack);
+    }
+
+    componentWillUnmount() {
+        // Removes the BackHandler EventListener when unmounting
+        BackHandler.removeEventListener('hardwareBackPress', this._handleBack);
     }
 
     // delete draft from asyncstorage

--- a/src/screens/TemplateScreen.js
+++ b/src/screens/TemplateScreen.js
@@ -6,7 +6,6 @@ import {
     ScrollView,
     NetInfo,
     StatusBar,
-    Platform,
 } from 'react-native';
 import { connect } from 'react-redux';
 
@@ -14,13 +13,13 @@ import templateScreenStyles from './style/templateScreenStyles';
 import { Layout } from '../components/Layout';
 import { AppBackground } from '../components/AppBackground';
 import { ReportSearchBar } from '../components/ReportSearchBar';
-import { fetchReportsByTemplateID, fetchTemplatesByUsername, fetchDraftsByTemplateID, isNetworkConnected } from './api';
+import { fetchReportsByTemplateID, fetchTemplatesByUsername, fetchDraftsByTemplateID } from './api';
 import { storeTemplates } from '../redux/actions/templates';
 import { storeReportsByTemplateID, storeDraftByTemplateID, insertTemplateID } from '../redux/actions/reports';
 import { preview } from '../redux/actions/preview';
 import userReducer from '../redux/reducers/user';
 
-import { setInitialConnection, toggleConnection } from '../redux/actions/connection';
+import { toggleConnection } from '../redux/actions/connection';
 
 // "export" necessary in order to test component without Redux store
 export class TemplateScreen extends Component {
@@ -59,7 +58,7 @@ export class TemplateScreen extends Component {
     */
     componentDidMount() {
 
-        if (Platform.OS === 'android') NetInfo.isConnected.addEventListener('connectionChange', this.handleConnectionChange);
+        NetInfo.isConnected.addEventListener('connectionChange', this.handleConnectionChange);
         // TEMPORARY: not sure if this is the best solution. Current version fixes a bug (related to logging in)
         if (this.props.username !== userReducer.username) {
             this.getTemplatesAndReports();
@@ -70,7 +69,7 @@ export class TemplateScreen extends Component {
     }
 
     componentWillUnmount() {
-        if (Platform.OS === 'android') NetInfo.isConnected.removeEventListener('connectionChange', this.handleConnectionChange);
+        NetInfo.isConnected.removeEventListener('connectionChange', this.handleConnectionChange);
     }
 
     handleConnectionChange = isConnected => {

--- a/src/screens/api.js
+++ b/src/screens/api.js
@@ -68,8 +68,11 @@ export const fetchRemoteEmptyTemplate = (username, templateID, token) => {
     );
 };
 
-// used to store drafts
+// Used to store drafts. All drafts are stored under the same templateID, and are therefore stored inside arrays.
 export const saveDraft = (username, templateID, draft) => {
+    // In case an empty draft is given, it won't be saved in AsyncStorage.
+    if (Object.keys(draft).length === 0) return;
+
     fetchDraftsByTemplateID(username, templateID)
         .then((drafts) => {
             // see if there is already a draft with the same id

--- a/src/screens/api.js
+++ b/src/screens/api.js
@@ -296,8 +296,8 @@ const removeData = (dataUrl) => {
 };
 */
 
-// Necessary because of a bug on iOS https://github.com/facebook/react-native/issues/8615#issuecomment-287977178
-export function isNetworkConnected() {
+// Necessary because of a bug on iOS https://github.com/facebook/react-native/issues/8615#issuecomment-287977178?
+/* Is this really necessary? TODO: Testing this change with the android peeps
     if (Platform.OS === 'ios') {
         return new Promise(resolve => {
             const handleFirstConnectivityChangeIOS = isConnected => {
@@ -307,6 +307,8 @@ export function isNetworkConnected() {
             NetInfo.isConnected.addEventListener('connectionChange', handleFirstConnectivityChangeIOS);
         });
     }
+ */
+export function isNetworkConnected() {
 
     return NetInfo.isConnected.fetch();
 }


### PR DESCRIPTION
This PR includes the branch IOSandBugs and work on the unsaved-alert (the alert that is shown when trying to exit a screen where a report is being edited).

The alert text is now changed and saving the report from the alert should now work.

For now the alert assumes that an edited report is always unsaved: checking this isn't implemented yet.